### PR TITLE
ITSASU-5248

### DIFF
--- a/app/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/controllers/individual/BusinessNameController.scala
+++ b/app/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/controllers/individual/BusinessNameController.scala
@@ -89,7 +89,7 @@ class BusinessNameController @Inject()(businessNameView: BusinessName,
         if (isEditMode || isGlobalEdit) {
           Redirect(routes.SelfEmployedCYAController.show(id, isEditMode, isGlobalEdit))
         } else {
-          Redirect(routes.FullIncomeSourceController.show(id, isEditMode, isGlobalEdit))
+          Redirect(routes.BusinessStartDateBeforeLimitController.show(id, isEditMode, isGlobalEdit))
         }
       case Left(_) =>
         throw new InternalServerException("[BusinessNameController][submit] - Could not save business name")

--- a/app/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/controllers/individual/BusinessNameController.scala
+++ b/app/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/controllers/individual/BusinessNameController.scala
@@ -89,7 +89,6 @@ class BusinessNameController @Inject()(businessNameView: BusinessName,
         if (isEditMode || isGlobalEdit) {
           Redirect(routes.SelfEmployedCYAController.show(id, isEditMode, isGlobalEdit))
         } else {
-          // TODO: confirm next page in journey with Alex
           Redirect(routes.FullIncomeSourceController.show(id, isEditMode, isGlobalEdit))
         }
       case Left(_) =>

--- a/app/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/controllers/individual/BusinessNameController.scala
+++ b/app/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/controllers/individual/BusinessNameController.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.controllers.individual
+
+import play.api.data.Form
+import play.api.i18n.I18nSupport
+import play.api.mvc._
+import play.twirl.api.Html
+import uk.gov.hmrc.http.{HeaderCarrier, InternalServerException}
+import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.config.AppConfig
+import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.controllers.utils.ReferenceRetrieval
+import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.forms.individual.BusinessNameForm
+import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.services.{AuthService, MultipleSelfEmploymentsService, SessionDataService}
+import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.views.html.individual.BusinessName
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import uk.gov.hmrc.play.language.LanguageUtils
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class BusinessNameController @Inject()(businessNameView: BusinessName,
+                                       mcc: MessagesControllerComponents,
+                                       multipleSelfEmploymentsService: MultipleSelfEmploymentsService,
+                                       authService: AuthService)
+                                      (val sessionDataService: SessionDataService,
+                                       val languageUtils: LanguageUtils,
+                                       val appConfig: AppConfig)
+                                      (implicit val ec: ExecutionContext)
+  extends FrontendController(mcc) with ReferenceRetrieval with I18nSupport {
+
+  def show(id: String, isEditMode: Boolean, isGlobalEdit: Boolean): Action[AnyContent] = Action.async { implicit request =>
+    authService.authorised() {
+      withIndividualReference { reference =>
+        populateFormFromSavedDetails(reference, id) map { form =>
+          Ok(view(
+            businessNameForm = form,
+            id = id,
+            isEditMode = isEditMode,
+            isGlobalEdit = isGlobalEdit
+          ))
+        }
+      }
+    }
+  }
+
+  def submit(id: String, isEditMode: Boolean, isGlobalEdit: Boolean): Action[AnyContent] = Action.async { implicit request =>
+    authService.authorised() {
+      withIndividualReference { reference =>
+        BusinessNameForm.businessNameForm.bindFromRequest().fold(
+          formWithErrors =>
+            Future.successful(BadRequest(view(formWithErrors, id, isEditMode, isGlobalEdit))),
+          name =>
+            saveAndContinue(reference, id, name, isEditMode, isGlobalEdit)
+        )
+      }
+    }
+  }
+
+  private def populateFormFromSavedDetails(reference: String, id: String)
+                                          (implicit hc: HeaderCarrier): Future[Form[String]] =
+    multipleSelfEmploymentsService.fetchStreamlineData(reference, id) map {
+      case Some(streamlineBusiness) =>
+        BusinessNameForm.businessNameForm
+          .bind(BusinessNameForm.createBusinessNameData(streamlineBusiness.name))
+          .discardingErrors
+      case None =>
+        BusinessNameForm.businessNameForm
+    }
+
+  private def saveAndContinue(reference: String, id: String, name: String, isEditMode: Boolean, isGlobalEdit: Boolean)
+                             (implicit hc: HeaderCarrier): Future[Result] =
+    multipleSelfEmploymentsService.saveBusinessName(reference, id, name) map {
+      case Right(_) =>
+        if (isEditMode || isGlobalEdit) {
+          Redirect(routes.SelfEmployedCYAController.show(id, isEditMode, isGlobalEdit))
+        } else {
+          // TODO: confirm next page in journey with Alex
+          Redirect(routes.FullIncomeSourceController.show(id, isEditMode, isGlobalEdit))
+        }
+      case Left(_) =>
+        throw new InternalServerException("[BusinessNameController][submit] - Could not save business name")
+    }
+
+  private def view(businessNameForm: Form[String], id: String, isEditMode: Boolean, isGlobalEdit: Boolean)
+                  (implicit request: Request[AnyContent]): Html =
+    businessNameView(
+      businessNameForm = businessNameForm,
+      postAction = routes.BusinessNameController.submit(id, isEditMode, isGlobalEdit),
+      isEditMode = isEditMode || isGlobalEdit
+    )
+
+}

--- a/app/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/forms/individual/BusinessNameForm.scala
+++ b/app/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/forms/individual/BusinessNameForm.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.forms.individual
+
+import play.api.data.Form
+import play.api.data.Forms.single
+import play.api.data.validation.Constraint
+import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.forms.constraints.StringConstraints.*
+import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.forms.utils.ConstraintUtil.ConstraintUtil
+import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.forms.utils.MappingUtil.trimmedText
+
+object BusinessNameForm {
+
+  val businessName: String = "business-name"
+  val pageIdentifier: String = "full-income-source"
+
+  private val businessNameAndTradeAllowedCharacters = """^[A-Za-z0-9 ,.&'\\/-]*$"""
+  private val businessNameMaxLength: Int = 105
+  private val businessNameMinLength: Int = 2
+
+  val nameNotEmpty: Constraint[String] = nonEmpty(s"individual.error.$pageIdentifier.$businessName.empty")
+  val nameMaxLength: Constraint[String] = maxLength(businessNameMaxLength, s"individual.error.$pageIdentifier.$businessName.max-length")
+  val nameMinLength: Constraint[String] = minLettersLength(businessNameMinLength, s"individual.error.$pageIdentifier.$businessName.min-length")
+  val nameValidChars: Constraint[String] = validateCharAgainst(businessNameAndTradeAllowedCharacters, s"individual.error.$pageIdentifier.$businessName.invalid-character")
+
+  val businessNameForm: Form[String] = Form(
+    single(
+      businessName -> trimmedText.verifying(nameNotEmpty andThen nameMaxLength andThen nameValidChars andThen nameMinLength)
+    )
+  )
+
+  def createBusinessNameData(maybeBusinessName: Option[String]): Map[String, String] =
+    maybeBusinessName.fold(Map.empty[String, String])(name => Map(businessName -> name))
+
+}

--- a/app/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/forms/individual/BusinessNameForm.scala
+++ b/app/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/forms/individual/BusinessNameForm.scala
@@ -35,7 +35,7 @@ object BusinessNameForm {
   val nameNotEmpty: Constraint[String] = nonEmpty(s"individual.error.$pageIdentifier.$businessName.empty")
   val nameMaxLength: Constraint[String] = maxLength(businessNameMaxLength, s"individual.error.$pageIdentifier.$businessName.max-length")
   val nameMinLength: Constraint[String] = minLettersLength(businessNameMinLength, s"individual.error.$pageIdentifier.$businessName.min-length")
-  val nameValidChars: Constraint[String] = validateCharAgainst(businessNameAndTradeAllowedCharacters, s"individual.error.$pageIdentifier.$businessName.invalid-character")
+  val nameValidChars: Constraint[String] = validateCharAgainst(businessNameAndTradeAllowedCharacters, s"individual.error.$pageIdentifier.$businessName.invalid")
 
   val businessNameForm: Form[String] = Form(
     single(

--- a/app/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/services/MultipleSelfEmploymentsService.scala
+++ b/app/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/services/MultipleSelfEmploymentsService.scala
@@ -150,6 +150,10 @@ class MultipleSelfEmploymentsService @Inject()(applicationCrypto: ApplicationCry
     saveData(reference, businessId, _.copy(startDate = Some(startDate), confirmed = false))
   }
 
+  def saveBusinessName(reference: String, businessId: String, name: String)
+                      (implicit hc: HeaderCarrier): Future[Either[SaveSelfEmploymentDataFailure.type, PostSubscriptionDetailsSuccess]] =
+    saveData(reference, businessId, _.copy(name = Some(name), confirmed = false))
+
   def saveAddress(reference: String, businessId: String, address: Address)
                  (implicit hc: HeaderCarrier): Future[Either[SaveSelfEmploymentDataFailure.type, PostSubscriptionDetailsSuccess]] = {
     saveData(reference, businessId, _.copy(address = Some(address), confirmed = false))

--- a/app/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/views/individual/BusinessName.scala.html
+++ b/app/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/views/individual/BusinessName.scala.html
@@ -14,9 +14,8 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.utilities.AccountingPeriodUtil
-@import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.forms.individual.StreamlineIncomeSourceForm
-@import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.views.html.helpers.injected.{ RadioHelper, SaveAndContinueButtonHelper, PageHeadingHelper}
+@import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.forms.individual.BusinessNameForm
+@import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.views.html.helpers.injected.{ SaveAndContinueButtonHelper, PageHeadingHelper}
 @import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.views.html.templates.PrincipalMainTemplate
 @import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.views.html.templates.injected.TextInputHelper
 
@@ -28,9 +27,9 @@
     pageHeadingHelper: PageHeadingHelper
 )
 
-@(fullIncomeSourceForm: Form[_], postAction: Call, isEditMode: Boolean)(implicit request: Request[_], messages: Messages)
+@(businessNameForm: Form[String], postAction: Call, isEditMode: Boolean)(implicit request: Request[_], messages: Messages)
 
-@mainTemplate(title = messages("individual.business-name.title"), optForm = Some(fullIncomeSourceForm)) {
+@mainTemplate(title = messages("individual.business-name.title"), optForm = Some(businessNameForm)) {
 
     @pageHeadingHelper(
         heading = messages("individual.business-name.heading"),
@@ -42,7 +41,7 @@
 
     @form(action = postAction) {
         @textInputHelper(
-            field = fullIncomeSourceForm(StreamlineIncomeSourceForm.businessName),
+            field = businessNameForm(BusinessNameForm.businessName),
             label = messages("individual.business-name.heading-two"),
             hint = Some(Html(messages("individual.business-name.para-two"))),
             isPageHeading = false,

--- a/app/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/views/individual/BusinessName.scala.html
+++ b/app/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/views/individual/BusinessName.scala.html
@@ -1,0 +1,59 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.utilities.AccountingPeriodUtil
+@import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.forms.individual.StreamlineIncomeSourceForm
+@import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.views.html.helpers.injected.{ RadioHelper, SaveAndContinueButtonHelper, PageHeadingHelper}
+@import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.views.html.templates.PrincipalMainTemplate
+@import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.views.html.templates.injected.TextInputHelper
+
+@this(
+    mainTemplate: PrincipalMainTemplate,
+    form: FormWithCSRF,
+    textInputHelper: TextInputHelper,
+    saveAndContinueButtonHelper: SaveAndContinueButtonHelper,
+    pageHeadingHelper: PageHeadingHelper
+)
+
+@(fullIncomeSourceForm: Form[_], postAction: Call, isEditMode: Boolean)(implicit request: Request[_], messages: Messages)
+
+@mainTemplate(title = messages("individual.business-name.title"), optForm = Some(fullIncomeSourceForm)) {
+
+    @pageHeadingHelper(
+        heading = messages("individual.business-name.heading"),
+        caption = messages("individual.business-name.caption"),
+        isSection = true
+    )
+
+    <p class="govuk-body">@messages("individual.business-name.para-one")</p>
+
+    @form(action = postAction) {
+        @textInputHelper(
+            field = fullIncomeSourceForm(StreamlineIncomeSourceForm.businessName),
+            label = messages("individual.business-name.heading-two"),
+            isLabelHidden = true,
+            hint = Some(Html(messages("individual.business-name.para-two"))),
+            isPageHeading = false,
+            classes = Some("govuk-!-width-one-half"),
+            autoComplete = Some("organization")
+        )
+
+        @saveAndContinueButtonHelper(
+            individual = true,
+            saveAndReturnReference = Some("sole-trader-income-source")
+        )
+    }
+}

--- a/app/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/views/individual/BusinessName.scala.html
+++ b/app/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/views/individual/BusinessName.scala.html
@@ -44,7 +44,6 @@
         @textInputHelper(
             field = fullIncomeSourceForm(StreamlineIncomeSourceForm.businessName),
             label = messages("individual.business-name.heading-two"),
-            isLabelHidden = true,
             hint = Some(Html(messages("individual.business-name.para-two"))),
             isPageHeading = false,
             classes = Some("govuk-!-width-one-half"),

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -23,6 +23,9 @@ GET        /address-lookup-check/:businessId            uk.gov.hmrc.incometaxsub
 GET        /address-lookup-initialise/:businessId/:isUk uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.controllers.individual.AddressLookupRoutingController.initialiseAddressLookupJourney(businessId: String, isUk: Boolean, isEditMode: Boolean ?= false, isGlobalEdit: Boolean ?= false)
 GET        /details/address-lookup/:businessId          uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.controllers.individual.AddressLookupRoutingController.addressLookupRedirect(businessId: String, id: Option[String] ?= None, isEditMode: Boolean ?= false, isGlobalEdit: Boolean ?= false)
 
+GET        /business/sole-trader-business-name          uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.controllers.individual.BusinessNameController.show(id: String, isEditMode: Boolean ?= false, isGlobalEdit: Boolean ?= false)
+POST       /business/sole-trader-business-name          uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.controllers.individual.BusinessNameController.submit(id: String, isEditMode: Boolean ?= false, isGlobalEdit: Boolean ?= false)
+
 GET        /details/sole-trader-business                uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.controllers.individual.FullIncomeSourceController.show(id: String, isEditMode: Boolean ?= false, isGlobalEdit: Boolean ?= false)
 POST       /details/sole-trader-business                uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.controllers.individual.FullIncomeSourceController.submit(id: String, isEditMode: Boolean ?= false, isGlobalEdit: Boolean ?= false)
 

--- a/conf/messages
+++ b/conf/messages
@@ -77,10 +77,10 @@ individual.error.full-income-source.business-trade.empty                  = Ente
 individual.error.full-income-source.business-trade.max-length             = Trade must be 35 characters or less
 individual.error.full-income-source.business-trade.min-length             = Trade must have at least 2 letters (upper or lower case)
 individual.error.full-income-source.business-trade.invalid                = Your business trade name may only include the following characters:  upper case letters, lower case letters, full stops, commas, digits, &, '', \, /, -
-individual.error.full-income-source.business-name.empty                   = Enter your name or the name of your business
+individual.error.full-income-source.business-name.empty                   = Add your business name
 individual.error.full-income-source.business-name.max-length              = Business name must be 105 characters or less
 individual.error.full-income-source.business-name.min-length              = Business name must have at least 2 letters (upper or lower case)
-individual.error.full-income-source.business-name.invalid                 = Your business name may only include the following characters: upper case letters, lower case letters, full stops, commas, digits, &, '', \, /, -
+individual.error.full-income-source.business-name.invalid                 = The business name can only include upper case or lower case letters, full stops, commas, digits, &,’,/,\,-.
 individual.error.full-income-source.start-date-before-limit.empty         = Select ‘Yes’ if this business started before 6 April {0}
 
 # Duplicate details page
@@ -182,9 +182,9 @@ agent.error.full-income-source.business-trade.empty                  = Enter the
 agent.error.full-income-source.business-trade.max-length             = Business trade must be 35 characters or less
 agent.error.full-income-source.business-trade.min-length             = Your business trade name must include at least two letters (upper or lower case)
 agent.error.full-income-source.business-trade.invalid                = Your business trade name may only include the following characters:  upper case letters, lower case letters, full stops, commas, digits, &, '', \, /, -
-agent.error.full-income-source.business-name.empty                   = Add your business name
+agent.error.full-income-source.business-name.empty                   = Enter your client’s name or the name of their business
 agent.error.full-income-source.business-name.max-length              = Business name must be between 1 and 105 characters
-agent.error.full-income-source.business-name.invalid-character       = The business name can only include upper case or lower case letters, full stops, commas, digits, &,’,/,\,-.
+agent.error.full-income-source.business-name.invalid-character       = Your business name may only include the following characters: upper case letters, lower case letters, full stops, commas, digits, &, '', \, /, -
 agent.error.full-income-source.start-date.day-month-year.empty       = Enter the date your client’s business started trading
 agent.error.full-income-source.start-date.day.empty                  = The date must include a day
 agent.error.full-income-source.start-date.month.empty                = The date must include a month

--- a/conf/messages
+++ b/conf/messages
@@ -102,6 +102,14 @@ self-employed-cya.heading                                       = Check your ans
 self-employed-cya.caption                                       = Sole trader
 self-employed-cya.para                                          = Add or change any missing or incorrect details, then confirm that the information is correct.
 
+#Self Employed Business Name page
+individual.business-name.title                              = Your sole trader business name
+individual.business-name.heading                            = Business name
+individual.business-name.caption                            = Sole trader
+individual.business-name.para-one                           = This is the business name you used to register for Self Assessment. If your business does not have a name, enter your own first and last name.
+individual.business-name.heading-two                        = What is your business name?
+individual.business-name.para-two                           = The business name you enter can only include upper case or lower case letters, full stops, commas, digits, &, ’, /, \, -.
+
 # Agent Business start date
 business.agent.start-date.title                                 = Sole trader
 business.agent.start-date.heading                               = Business start date
@@ -174,9 +182,9 @@ agent.error.full-income-source.business-trade.empty                  = Enter the
 agent.error.full-income-source.business-trade.max-length             = Business trade must be 35 characters or less
 agent.error.full-income-source.business-trade.min-length             = Your business trade name must include at least two letters (upper or lower case)
 agent.error.full-income-source.business-trade.invalid                = Your business trade name may only include the following characters:  upper case letters, lower case letters, full stops, commas, digits, &, '', \, /, -
-agent.error.full-income-source.business-name.empty                   = Enter your client’s name or the name of their business
+agent.error.full-income-source.business-name.empty                   = Add your business name
 agent.error.full-income-source.business-name.max-length              = Business name must be between 1 and 105 characters
-agent.error.full-income-source.business-name.invalid-character       = Your business name may only include the following characters: upper case letters, lower case letters, full stops, commas, digits, &, '', \, /, -
+agent.error.full-income-source.business-name.invalid-character       = The business name can only include upper case or lower case letters, full stops, commas, digits, &,’,/,\,-.
 agent.error.full-income-source.start-date.day-month-year.empty       = Enter the date your client’s business started trading
 agent.error.full-income-source.start-date.day.empty                  = The date must include a day
 agent.error.full-income-source.start-date.month.empty                = The date must include a month

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -103,6 +103,14 @@ self-employed-cya.heading                                       = Gwiriwch eich 
 self-employed-cya.caption                                       = Unig fasnachwr
 self-employed-cya.para                                          = Ychwanegu neu newid unrhyw fanylion sydd ar goll neu'n anghywir.
 
+#Self Employed Business Name page
+individual.business-name.title                              = Eich busnes fel unig fasnachwr
+individual.business-name.heading                            = Enw’r busnes
+individual.business-name.caption                            = Unig fasnachwr
+individual.business-name.para-one                           = Dyma enw’r busnes a ddefnyddioch i gofrestru ar gyfer Hunanasesiad. Os nad oes gan eich busnes enw, nodwch eich enw llawn.
+individual.business-name.heading-two                        = What is your business name?
+individual.business-name.para-two                           = Gall enw'r busnes gnnwys llythrennau mawr neu fach, atalnodau llawn, comas, digidau, &, ', /, \, - yn unig.
+
 # Agent Business start date
 business.agent.start-date.title                                 = Unig fasnachwr
 business.agent.start-date.heading                               = Dyddiad dechrau’r busnes
@@ -175,9 +183,9 @@ agent.error.full-income-source.business-trade.empty                  = Nodwch fa
 agent.error.full-income-source.business-trade.max-length             = Mae‘n rhaid i fasnach y busnes fod yn 35 o gymeriadau neu lai
 agent.error.full-income-source.business-trade.min-length             = Mae’n rhaid i enw masnachu’ch busnes gynnwys o leiaf dwy lythyren (llythrennau mawr neu lythrennau bach)
 agent.error.full-income-source.business-trade.invalid                = Gall enw masnachu’ch busnes gynnwys y cymeriadau canlynol yn unig:  llythrennau mawr, llythrennau bach, atalnodau llawn, comas, digidau, &, '', \, /, -
-agent.error.full-income-source.business-name.empty                   = Nodwch enw’ch cleient neu enw busnes eich cleient
+agent.error.full-income-source.business-name.empty                   = Ychwanegwch enw’ch busnes
 agent.error.full-income-source.business-name.max-length              = Rhaid i’r enw busnes fod rhwng 1 a 105 o gymeriadau
-agent.error.full-income-source.business-name.invalid-character       = Gall enw’r busnes gynnwys llythrennau mawr neu fach, atalnodau llawn, comas, digidau, &,’,/,\,- yn unig
+agent.error.full-income-source.business-name.invalid-character       = Gall enw'r busnes gnnwys llythrennau mawr neu fach, atalnodau llawn, comas, digidau, &, ', /, \, - yn unig.
 agent.error.full-income-source.start-date.day-month-year.empty       = Nodwch y dyddiad y dechreuodd busnes eich cleient fasnachu
 agent.error.full-income-source.start-date.day.empty                  = Mae’n rhaid i’r dyddiad gynnwys diwrnod
 agent.error.full-income-source.start-date.month.empty                = Mae’n rhaid i’r dyddiad gynnwys mis

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -78,10 +78,10 @@ individual.error.full-income-source.business-trade.empty                = Nodwch
 individual.error.full-income-source.business-trade.max-length           = Mae’n rhaid i’r fasnach fod yn 35 o gymeriadau neu lai
 individual.error.full-income-source.business-trade.min-length           = Mae’n rhaid i’r fasnach gynnwys o leiaf 2 lythyren (llythrennau mawr neu lythrennau bach)
 individual.error.full-income-source.business-trade.invalid              = Gall enw masnachu’ch busnes gynnwys y cymeriadau canlynol yn unig:  llythrennau mawr, llythrennau bach, atalnodau llawn, comas, digidau, &, '', \, /, -
-individual.error.full-income-source.business-name.empty                 = Nodwch eich enw neu enw’ch busnes
+individual.error.full-income-source.business-name.empty                 = Ychwanegwch enw’ch busnes
 individual.error.full-income-source.business-name.max-length            = Mae’n rhaid i enw’r busnes fod yn 105 o gymeriadau neu lai
 individual.error.full-income-source.business-name.min-length            = Mae’n rhaid i enw’r busnes gynnwys o leiaf 2 lythyren (llythrennau mawr neu lythrennau bach)
-individual.error.full-income-source.business-name.invalid               = Gall enw’r busnes gynnwys llythrennau mawr neu fach, atalnodau llawn, comas, digidau, &,’,/,\,- yn unig
+individual.error.full-income-source.business-name.invalid               = Gall enw'r busnes gnnwys llythrennau mawr neu fach, atalnodau llawn, comas, digidau, &, ', /, \, - yn unig.
 individual.error.full-income-source.start-date-before-limit.empty       = Dewiswch ‘Iawn’ os oedd y busnes hwn wedi dechrau cyn 6 Ebrill {0}
 
 # Duplicate details page
@@ -183,9 +183,9 @@ agent.error.full-income-source.business-trade.empty                  = Nodwch fa
 agent.error.full-income-source.business-trade.max-length             = Mae‘n rhaid i fasnach y busnes fod yn 35 o gymeriadau neu lai
 agent.error.full-income-source.business-trade.min-length             = Mae’n rhaid i enw masnachu’ch busnes gynnwys o leiaf dwy lythyren (llythrennau mawr neu lythrennau bach)
 agent.error.full-income-source.business-trade.invalid                = Gall enw masnachu’ch busnes gynnwys y cymeriadau canlynol yn unig:  llythrennau mawr, llythrennau bach, atalnodau llawn, comas, digidau, &, '', \, /, -
-agent.error.full-income-source.business-name.empty                   = Ychwanegwch enw’ch busnes
+agent.error.full-income-source.business-name.empty                   = Nodwch enw’ch cleient neu enw busnes eich cleient
 agent.error.full-income-source.business-name.max-length              = Rhaid i’r enw busnes fod rhwng 1 a 105 o gymeriadau
-agent.error.full-income-source.business-name.invalid-character       = Gall enw'r busnes gnnwys llythrennau mawr neu fach, atalnodau llawn, comas, digidau, &, ', /, \, - yn unig.
+agent.error.full-income-source.business-name.invalid-character       = Gall enw’r busnes gynnwys llythrennau mawr neu fach, atalnodau llawn, comas, digidau, &,’,/,\,- yn
 agent.error.full-income-source.start-date.day-month-year.empty       = Nodwch y dyddiad y dechreuodd busnes eich cleient fasnachu
 agent.error.full-income-source.start-date.day.empty                  = Mae’n rhaid i’r dyddiad gynnwys diwrnod
 agent.error.full-income-source.start-date.month.empty                = Mae’n rhaid i’r dyddiad gynnwys mis

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -108,7 +108,7 @@ individual.business-name.title                              = Eich busnes fel un
 individual.business-name.heading                            = Enw’r busnes
 individual.business-name.caption                            = Unig fasnachwr
 individual.business-name.para-one                           = Dyma enw’r busnes a ddefnyddioch i gofrestru ar gyfer Hunanasesiad. Os nad oes gan eich busnes enw, nodwch eich enw llawn.
-individual.business-name.heading-two                        = What is your business name?
+individual.business-name.heading-two                        = Beth yw enw'r eich busnes?
 individual.business-name.para-two                           = Gall enw'r busnes gnnwys llythrennau mawr neu fach, atalnodau llawn, comas, digidau, &, ', /, \, - yn unig.
 
 # Agent Business start date

--- a/it/test/controllers/individual/BusinessNameControllerISpec.scala
+++ b/it/test/controllers/individual/BusinessNameControllerISpec.scala
@@ -117,8 +117,7 @@ class BusinessNameControllerISpec extends ComponentSpecBase {
 
         result must have(
           httpStatus(SEE_OTHER),
-          // TODO: update redirect once BusinessTradeNameController is created
-          redirectURI(routes.FullIncomeSourceController.show(id).url)
+          redirectURI(routes.BusinessStartDateBeforeLimitController.show(id).url)
         )
       }
     }

--- a/it/test/controllers/individual/BusinessNameControllerISpec.scala
+++ b/it/test/controllers/individual/BusinessNameControllerISpec.scala
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.individual
+
+import connectors.stubs.IncomeTaxSubscriptionConnectorStub._
+import helpers.ComponentSpecBase
+import helpers.IntegrationTestConstants._
+import helpers.servicemocks.AuthStub
+import play.api.http.Status._
+import play.api.libs.json.Json
+import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.SelfEmploymentDataKeys.{incomeSourcesComplete, soleTraderBusinessesKey}
+import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.controllers.individual.routes
+import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.models.{SoleTraderBusiness, SoleTraderBusinesses}
+
+class BusinessNameControllerISpec extends ComponentSpecBase {
+
+  s"GET ${routes.BusinessNameController.show(id)}" when {
+    "the user is unauthorised" should {
+      "redirect to the login page" in {
+        AuthStub.stubUnauthorised()
+
+        val result = getBusinessName(id)
+
+        result must have(
+          httpStatus(SEE_OTHER),
+          redirectURI(ggSignInURI)
+        )
+      }
+    }
+    "the user has previously entered a business name" should {
+      "display the page with the field filled" in {
+        AuthStub.stubAuthSuccess()
+        stubGetSubscriptionData(reference, soleTraderBusinessesKey)(
+          responseStatus = OK,
+          responseBody = Json.toJson(soleTraderBusinesses)
+        )
+
+        val result = getBusinessName(id)
+
+        result must have(
+          httpStatus(OK),
+          pageTitle(messages("individual.business-name.title") + titleSuffix),
+          textField("business-name", "test name")
+        )
+      }
+    }
+    "the user has not been on the page before for this business" should {
+      "display the page with the field empty" in {
+        AuthStub.stubAuthSuccess()
+        stubGetSubscriptionData(reference, soleTraderBusinessesKey)(NO_CONTENT)
+
+        val result = getBusinessName(id)
+
+        result must have(
+          httpStatus(OK),
+          pageTitle(messages("individual.business-name.title") + titleSuffix),
+          textField("business-name", "")
+        )
+      }
+    }
+  }
+
+  s"POST ${routes.BusinessNameController.submit(id)}" when {
+    "the user is unauthorised" should {
+      "redirect to the login page" in {
+        AuthStub.stubUnauthorised()
+
+        val result = submitBusinessName(name = Some("test name"), id = id)
+
+        result must have(
+          httpStatus(SEE_OTHER),
+          redirectURI(ggSignInURI)
+        )
+      }
+    }
+    "the user submits with no business name" should {
+      "return a bad request with the page content" in {
+        AuthStub.stubAuthSuccess()
+
+        val result = submitBusinessName(name = None, id = id)
+
+        result must have(
+          httpStatus(BAD_REQUEST),
+          pageTitle("Error: " + messages("individual.business-name.title") + titleSuffix)
+        )
+      }
+    }
+    "the user submits a valid business name" should {
+      "save the name and redirect to the next page" in {
+        AuthStub.stubAuthSuccess()
+        stubGetSubscriptionData(reference, soleTraderBusinessesKey)(NO_CONTENT)
+        stubSaveSubscriptionData(
+          reference = reference,
+          id = soleTraderBusinessesKey,
+          body = Json.toJson(SoleTraderBusinesses(Seq(SoleTraderBusiness(
+            id = id,
+            name = Some("test name")
+          ))))
+        )(OK)
+        stubDeleteSubscriptionData(reference, incomeSourcesComplete)(OK)
+
+        val result = submitBusinessName(name = Some("test name"), id = id)
+
+        result must have(
+          httpStatus(SEE_OTHER),
+          // TODO: update redirect once BusinessTradeNameController is created
+          redirectURI(routes.FullIncomeSourceController.show(id).url)
+        )
+      }
+    }
+    "the user submits a valid business name in edit mode" should {
+      "save the name and redirect to the check your answers page" in {
+        AuthStub.stubAuthSuccess()
+        stubGetSubscriptionData(reference, soleTraderBusinessesKey)(
+          responseStatus = OK,
+          responseBody = Json.toJson(SoleTraderBusinesses(Seq(SoleTraderBusiness(
+            id = id,
+            name = Some("old name")
+          ))))
+        )
+        stubSaveSubscriptionData(
+          reference = reference,
+          id = soleTraderBusinessesKey,
+          body = Json.toJson(SoleTraderBusinesses(Seq(SoleTraderBusiness(
+            id = id,
+            name = Some("test name")
+          ))))
+        )(OK)
+        stubDeleteSubscriptionData(reference, incomeSourcesComplete)(OK)
+
+        val result = submitBusinessName(name = Some("test name"), id = id, isEditMode = true)
+
+        result must have(
+          httpStatus(SEE_OTHER),
+          redirectURI(routes.SelfEmployedCYAController.show(id, isEditMode = true).url)
+        )
+      }
+    }
+    "the user submits a valid business name in global edit mode" should {
+      "save the name and redirect to the check your answers page" in {
+        AuthStub.stubAuthSuccess()
+        stubGetSubscriptionData(reference, soleTraderBusinessesKey)(NO_CONTENT)
+        stubSaveSubscriptionData(
+          reference = reference,
+          id = soleTraderBusinessesKey,
+          body = Json.toJson(SoleTraderBusinesses(Seq(SoleTraderBusiness(
+            id = id,
+            name = Some("test name")
+          ))))
+        )(OK)
+        stubDeleteSubscriptionData(reference, incomeSourcesComplete)(OK)
+
+        val result = submitBusinessName(name = Some("test name"), id = id, isGlobalEdit = true)
+
+        result must have(
+          httpStatus(SEE_OTHER),
+          redirectURI(routes.SelfEmployedCYAController.show(id, isGlobalEdit = true).url)
+        )
+      }
+    }
+  }
+}

--- a/it/test/helpers/ComponentSpecBase.scala
+++ b/it/test/helpers/ComponentSpecBase.scala
@@ -25,7 +25,6 @@ import play.api.i18n.{Messages, MessagesApi}
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.crypto.DefaultCookieSigner
 import play.api.libs.json.{JsString, OFormat}
-import play.api.libs.ws.DefaultBodyWritables.writeableOf_urlEncodedForm
 import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
@@ -35,6 +34,8 @@ import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.forms.agent.Streaml
 import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.forms.individual.{StreamlineIncomeSourceForm as IndividualStreamlineIncomeSourceForm, *}
 import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.models.*
 import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.utilities.ITSASessionKeys.REFERENCE
+import play.api.libs.ws.DefaultBodyWritables.writeableOf_urlEncodedForm
+
 
 import java.time.LocalDate
 
@@ -166,6 +167,14 @@ trait ComponentSpecBase extends PlaySpec with CustomMatchers with GuiceOneServer
     )
   }
 
+  def getBusinessName(id: String, isEditMode: Boolean = false, isGlobalEdit: Boolean = false): WSResponse =
+    get(s"/business/sole-trader-business-name?id=$id&isEditMode=$isEditMode&isGlobalEdit=$isGlobalEdit")
+
+  def submitBusinessName(name: Option[String], id: String, isEditMode: Boolean = false, isGlobalEdit: Boolean = false): WSResponse =
+    post(s"/business/sole-trader-business-name?id=$id&isEditMode=$isEditMode&isGlobalEdit=$isGlobalEdit")(
+      name.fold(Map.empty[String, Seq[String]])(n => Map(BusinessNameForm.businessName -> Seq(n)))
+    )
+
   def getBusinessStartDateBeforeLimit(id: String, isEditMode: Boolean, isGlobalEdit: Boolean): WSResponse = {
     get(s"/details/business-start-date-before-limit?id=$id&isEditMode=$isEditMode&isGlobalEdit=$isGlobalEdit")
   }
@@ -216,7 +225,6 @@ trait ComponentSpecBase extends PlaySpec with CustomMatchers with GuiceOneServer
   def getClientTimeout: WSResponse = get(uri = "/client/timeout")
 
   def sessionTimeout(): WSResponse = get("/session-timeout")
-
   def clientSessionTimeout(): WSResponse = get("/client/session-timeout")
 
   def getKeepAlive: WSResponse = get(uri = "/keep-alive")

--- a/test/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/forms/individual/BusinessNameFormSpec.scala
+++ b/test/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/forms/individual/BusinessNameFormSpec.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.forms.individual
+
+import org.scalatestplus.play.PlaySpec
+import play.api.data.{Form, FormError}
+import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.forms.individual.BusinessNameForm._
+
+class BusinessNameFormSpec extends PlaySpec {
+
+  def form: Form[String] = businessNameForm
+
+  lazy val testNameMinLength = "AA"
+  lazy val testNameMaxLength: String = "A" * 105
+  lazy val testNameInvalidChar = "!@£$%^*():;"
+
+  "businessNameForm" should {
+    "bind valid data" when {
+      "business name has the minimum 2 characters" in {
+        val testInput = Map(businessName -> testNameMinLength)
+        val actual = form.bind(testInput).value
+
+        actual mustBe Some(testNameMinLength)
+      }
+
+      "business name is exactly 105 characters" in {
+        val testInput = Map(businessName -> testNameMaxLength)
+        val actual = form.bind(testInput).value
+
+        actual mustBe Some(testNameMaxLength)
+      }
+    }
+
+    "fail to bind" when {
+      "business name is empty" in {
+        val testInput = Map(businessName -> "")
+        val result = form.bind(testInput)
+        result.value mustBe None
+
+        result.errors must contain(FormError(businessName, s"individual.error.$pageIdentifier.$businessName.empty"))
+      }
+
+      "business name has just a space" in {
+        val testInput = Map(businessName -> " ")
+        val result = form.bind(testInput)
+        result.value mustBe None
+
+        result.errors must contain(FormError(businessName, s"individual.error.$pageIdentifier.$businessName.empty"))
+      }
+
+      "business name is too short" in {
+        val testInput = Map(businessName -> "A")
+        val result = form.bind(testInput)
+        result.value mustBe None
+
+        result.errors must contain(FormError(businessName, s"individual.error.$pageIdentifier.$businessName.min-length"))
+      }
+
+      "business name is too long (over 105 characters)" in {
+        val testInput = Map(businessName -> (testNameMaxLength + "A"))
+        val result = form.bind(testInput)
+        result.value mustBe None
+
+        result.errors must contain(FormError(businessName, s"individual.error.$pageIdentifier.$businessName.max-length"))
+      }
+
+      "business name has invalid characters" in {
+        val testInput = Map(businessName -> testNameInvalidChar)
+        val result = form.bind(testInput)
+        result.value mustBe None
+
+        result.errors must contain(FormError(businessName, s"individual.error.$pageIdentifier.$businessName.invalid-character"))
+      }
+    }
+  }
+
+  "unbind data correctly" in {
+    val filledForm = form.fill("Test Business Name")
+
+    filledForm.data must contain(businessName -> "Test Business Name")
+  }
+
+  "createBusinessNameData" should {
+    "return an empty mapping" when {
+      "nothing is supplied" in {
+        val result = createBusinessNameData(None)
+
+        result mustBe Map.empty[String, String]
+      }
+    }
+    "return a mapping of the name key to the value" when {
+      "a name is supplied" in {
+        val result = createBusinessNameData(Some("test name"))
+
+        result mustBe Map(businessName -> "test name")
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/forms/individual/BusinessNameFormSpec.scala
+++ b/test/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/forms/individual/BusinessNameFormSpec.scala
@@ -83,7 +83,7 @@ class BusinessNameFormSpec extends PlaySpec {
         val result = form.bind(testInput)
         result.value mustBe None
 
-        result.errors must contain(FormError(businessName, s"individual.error.$pageIdentifier.$businessName.invalid-character"))
+        result.errors must contain(FormError(businessName, s"individual.error.$pageIdentifier.$businessName.invalid"))
       }
     }
   }

--- a/test/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/views/individual/BusinessNameViewSpec.scala
+++ b/test/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/views/individual/BusinessNameViewSpec.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.views.individual
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.{Document, Element}
+import play.api.data.Form
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.forms.individual.StreamlineIncomeSourceForm
+import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.models.YesNo
+import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.utilities.ViewSpec
+import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.views.html.individual.BusinessName as BusinessNameView
+
+class BusinessNameViewSpec extends ViewSpec {
+
+  val businessNameView: BusinessNameView = app.injector.instanceOf[BusinessNameView]
+  val form: Form[(String, String, YesNo)] = StreamlineIncomeSourceForm.fullIncomeSourceForm
+
+  def view(errors: Boolean = false): HtmlFormat.Appendable = businessNameView(
+    fullIncomeSourceForm = if (errors) form.bind(Map.empty[String, String]) else form,
+    postAction = testCall,
+    isEditMode = false
+  )(fakeTestRequest, implicitly)
+
+  val document: Document = Jsoup.parse(view().body)
+
+  def mainContent: Element = document.mainContent
+
+  "FullIncomeSource" must {
+    import BusinessNameMessages.*
+
+    "use the correct template" when {
+      "there are no errors" in new TemplateViewTest(
+        view = view(),
+        title = BusinessNameMessages.title,
+        isAgent = false,
+        hasSignOutLink = true
+      )
+      "there are errors" in new TemplateViewTest(
+        view = view(errors = true),
+        title = BusinessNameMessages.title,
+        isAgent = false,
+        hasSignOutLink = true,
+        errors = Some(Seq(StreamlineIncomeSourceForm.businessName -> "Enter your name or the name of your business"))
+      )
+    }
+
+    "have the correct heading and caption" in {
+      mainContent.mustHaveHeadingAndCaption(
+        heading = BusinessNameMessages.heading,
+        caption = BusinessNameMessages.caption,
+        isSection = true
+      )
+    }
+
+    "have the correct paragraph" in {
+      val text = mainContent.selectHead(".govuk-body").text
+      text mustBe BusinessNameMessages.paragraph
+    }
+
+    "have a form" which {
+      def form: Element = mainContent.getForm
+
+      "has the correct attributes" in {
+        document.getForm.attr("method") mustBe testCall.method
+        document.getForm.attr("action") mustBe testCall.url
+      }
+
+      "have a text input to capture a business name" in {
+        form.mustHaveTextInput(".govuk-form-group:nth-of-type(2)")(
+          name = StreamlineIncomeSourceForm.businessName,
+          label = businessNameLabel,
+          isLabelHidden = false,
+          isPageHeading = false,
+          hint = Some(businessNameHint),
+          autoComplete = Some("organization")
+        )
+      }
+
+      "have a save and continue button" in {
+        form.selectNth(".govuk-button", 1).text mustBe Buttons.saveAndContinue
+      }
+
+      "have a save and come back later button" in {
+        form.selectNth(".govuk-button", 2).text mustBe Buttons.saveAndComeBackLater
+      }
+    }
+  }
+
+
+  object BusinessNameMessages {
+    val heading = "Business name"
+    val title = "Your sole trader business name"
+    val caption = "Sole trader"
+    val paragraph = "This is the business name you used to register for Self Assessment. If your business does not have a name, enter your own first and last name."
+    val businessNameLabel = "What is your business name?"
+    val businessNameHint = "The business name you enter can only include upper case or lower case letters, full stops, commas, digits, &, ’, /, \\, -."
+    
+    object Buttons {
+      val saveAndContinue = "Save and continue"
+      val saveAndComeBackLater = "Save and come back later"
+    }
+  }
+}

--- a/test/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/views/individual/BusinessNameViewSpec.scala
+++ b/test/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/views/individual/BusinessNameViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,23 +20,17 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 import play.api.data.Form
 import play.twirl.api.HtmlFormat
-import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.forms.individual.StreamlineIncomeSourceForm
-import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.models.YesNo
+import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.forms.individual.BusinessNameForm
 import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.utilities.ViewSpec
 import uk.gov.hmrc.incometaxsubscriptionselfemployedfrontend.views.html.individual.BusinessName as BusinessNameView
 
 class BusinessNameViewSpec extends ViewSpec {
 
   val businessNameView: BusinessNameView = app.injector.instanceOf[BusinessNameView]
-  val form: Form[(String, String, YesNo)] = StreamlineIncomeSourceForm.fullIncomeSourceForm
+  val form: Form[String] = BusinessNameForm.businessNameForm
 
   def view(errors: Boolean = false): HtmlFormat.Appendable = businessNameView(
-    fullIncomeSourceForm = if (errors)
-      form.bind(Map(
-        StreamlineIncomeSourceForm.businessTradeName -> "Plumbing",
-        StreamlineIncomeSourceForm.startDateBeforeLimit -> "No"
-      ))
-    else form,
+    businessNameForm = if (errors) form.bind(Map.empty[String, String]) else form,
     postAction = testCall,
     isEditMode = false
   )(fakeTestRequest, implicitly)
@@ -45,36 +39,35 @@ class BusinessNameViewSpec extends ViewSpec {
 
   def mainContent: Element = document.mainContent
 
-  "FullIncomeSource" must {
+  "BusinessName" must {
     import BusinessNameMessages.*
 
     "use the correct template" when {
       "there are no errors" in new TemplateViewTest(
         view = view(),
-        title = BusinessNameMessages.title,
+        title = title,
         isAgent = false,
         hasSignOutLink = true
       )
       "there are errors" in new TemplateViewTest(
         view = view(errors = true),
-        title = BusinessNameMessages.title,
+        title = title,
         isAgent = false,
         hasSignOutLink = true,
-        errors = Some(Seq(StreamlineIncomeSourceForm.businessName -> "Add your business name"))
+        errors = Some(Seq(BusinessNameForm.businessName -> "Add your business name"))
       )
     }
 
     "have the correct heading and caption" in {
       mainContent.mustHaveHeadingAndCaption(
-        heading = BusinessNameMessages.heading,
-        caption = BusinessNameMessages.caption,
+        heading = heading,
+        caption = caption,
         isSection = true
       )
     }
 
     "have the correct paragraph" in {
-      val text = mainContent.selectHead(".govuk-body").text
-      text mustBe BusinessNameMessages.paragraph
+      mainContent.selectHead(".govuk-body").text mustBe paragraph
     }
 
     "have a form" which {
@@ -85,9 +78,9 @@ class BusinessNameViewSpec extends ViewSpec {
         document.getForm.attr("action") mustBe testCall.url
       }
 
-      "have a text input to capture a business name" in {
-        form.mustHaveTextInput(".govuk-form-group:nth-of-type(1)")(
-          name = StreamlineIncomeSourceForm.businessName,
+      "has a text input to capture a business name" in {
+        form.mustHaveTextInput(".govuk-form-group")(
+          name = BusinessNameForm.businessName,
           label = businessNameLabel,
           isLabelHidden = false,
           isPageHeading = false,
@@ -96,16 +89,15 @@ class BusinessNameViewSpec extends ViewSpec {
         )
       }
 
-      "have a save and continue button" in {
+      "has a save and continue button" in {
         form.selectNth(".govuk-button", 1).text mustBe Buttons.saveAndContinue
       }
 
-      "have a save and come back later button" in {
+      "has a save and come back later button" in {
         form.selectNth(".govuk-button", 2).text mustBe Buttons.saveAndComeBackLater
       }
     }
   }
-
 
   object BusinessNameMessages {
     val heading = "Business name"

--- a/test/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/views/individual/BusinessNameViewSpec.scala
+++ b/test/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/views/individual/BusinessNameViewSpec.scala
@@ -31,7 +31,12 @@ class BusinessNameViewSpec extends ViewSpec {
   val form: Form[(String, String, YesNo)] = StreamlineIncomeSourceForm.fullIncomeSourceForm
 
   def view(errors: Boolean = false): HtmlFormat.Appendable = businessNameView(
-    fullIncomeSourceForm = if (errors) form.bind(Map.empty[String, String]) else form,
+    fullIncomeSourceForm = if (errors)
+      form.bind(Map(
+        StreamlineIncomeSourceForm.businessTradeName -> "Plumbing",
+        StreamlineIncomeSourceForm.startDateBeforeLimit -> "No"
+      ))
+    else form,
     postAction = testCall,
     isEditMode = false
   )(fakeTestRequest, implicitly)
@@ -55,7 +60,7 @@ class BusinessNameViewSpec extends ViewSpec {
         title = BusinessNameMessages.title,
         isAgent = false,
         hasSignOutLink = true,
-        errors = Some(Seq(StreamlineIncomeSourceForm.businessName -> "Enter your name or the name of your business"))
+        errors = Some(Seq(StreamlineIncomeSourceForm.businessName -> "Add your business name"))
       )
     }
 
@@ -81,7 +86,7 @@ class BusinessNameViewSpec extends ViewSpec {
       }
 
       "have a text input to capture a business name" in {
-        form.mustHaveTextInput(".govuk-form-group:nth-of-type(2)")(
+        form.mustHaveTextInput(".govuk-form-group:nth-of-type(1)")(
           name = StreamlineIncomeSourceForm.businessName,
           label = businessNameLabel,
           isLabelHidden = false,

--- a/test/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/views/individual/FullIncomeSourceViewSpec.scala
+++ b/test/uk/gov/hmrc/incometaxsubscriptionselfemployedfrontend/views/individual/FullIncomeSourceViewSpec.scala
@@ -60,7 +60,7 @@ class FullIncomeSourceViewSpec extends ViewSpec {
         hasSignOutLink = true,
         errors = Some(Seq(
           StreamlineIncomeSourceForm.businessTradeName -> "Enter the trade of this business",
-          StreamlineIncomeSourceForm.businessName -> "Enter your name or the name of your business",
+          StreamlineIncomeSourceForm.businessName -> "Add your business name",
           StreamlineIncomeSourceForm.startDateBeforeLimit -> s"Select ‘Yes’ if this business started before 6 April ${AccountingPeriodUtil.getStartDateLimit.getYear}"
         ))
       )


### PR DESCRIPTION
**BusinessName Page — Streamlined Sole Trader Journey**

This PR introduces a standalone `BusinessName` page as part of splitting the existing `FullIncomeSourceController` into separate individual journey pages.

**New files:**

- `forms/individual/BusinessNameForm.scala` — Extracts business name validation from `StreamlineIncomeSourceForm` into a standalone `Form[String]`, with constraints for empty, max length (105), min length (2), and invalid characters
- `controllers/individual/BusinessNameController.scala` — New controller handling `show` and `submit` for the business name page, following the same auth and reference retrieval pattern as `FullIncomeSourceController`
- `forms/individual/BusinessNameFormSpec.scala` — Unit tests covering all validation constraints and `createBusinessNameData`
- `controllers/individual/BusinessNameControllerISpec.scala` — Integration tests covering unauthorised access, GET with pre-filled/empty data, and POST for valid/invalid submissions and edit modes
- `views/html/individual/BusinessName.scala.html` — Updated parameter from `Form[_]` to `Form[String]`, renamed to `businessNameForm`, replaced `StreamlineIncomeSourceForm` import with `BusinessNameForm`
- `views/individual/BusinessNameViewSpec.scala` — Updated to use `BusinessNameForm` and simplified error binding to `Map.empty`

**Modified files:**

- `services/MultipleSelfEmploymentsService.scala` — Added `saveBusinessName` method delegating to the existing private `saveData` helper
- `helpers/ComponentSpecBase.scala` — Added `getBusinessName` and `submitBusinessName` test helpers
- `conf/routes` — Added GET and POST entries for `BusinessNameController`

**Redirect:** On successful submission, redirects to `BusinessStartDateBeforeLimitController` for the normal journey, or `SelfEmployedCYAController` when in edit or global edit mode.